### PR TITLE
[feature/toggle-button] 토글버튼 공통 컴포넌트 추가입니다.

### DIFF
--- a/shared/components/Toggle/Toggle.tsx
+++ b/shared/components/Toggle/Toggle.tsx
@@ -1,0 +1,54 @@
+import React, { MouseEvent, useState } from 'react';
+
+interface ToggleProps {
+  checked: boolean;
+  className?: string;
+  size?: 'lg' | 'sm';
+  onChange: (e: MouseEvent<HTMLInputElement>) => void;
+}
+
+export function Toggle({
+  checked,
+  onChange,
+  size = 'sm',
+  className,
+}: ToggleProps) {
+  const width = getStyleClassNamesBySize(size);
+
+  return (
+    <label className={`relative inline-flex items-center cursor-pointer aspect-video ${className}`} style={{ width }} >
+      <input type="checkbox" checked={checked} className="sr-only peer" onClick={onChange} />
+      <div className={`
+        w-[100%]
+        h-[100%]
+
+        bg-gray-30
+        rounded-full
+
+        peer
+        peer-focus:outline-none
+        peer-checked:bg-primary
+        peer-checked:after:translate-x-[85%]
+        peer-checked:after:border-white
+
+        after:w-[48%]
+        after:h-[85%]
+        after:content-['']
+        after:absolute
+        after:top-[7.5%]
+        after:left-[6%]
+        after:bg-white
+        after:rounded-full
+        after:transition-all
+      `}/>
+    </label>
+  );
+}
+
+function getStyleClassNamesBySize(size: ToggleProps['size']) {
+  if (size === 'sm') {
+    return '30px';
+  }
+
+  return '48px';
+}

--- a/shared/components/Toggle/index.ts
+++ b/shared/components/Toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './Toggle';


### PR DESCRIPTION
# 토글버튼

공통 컴포넌트 중 하나인 컴포넌트를 추가합니다.

[figma 링크](https://www.figma.com/file/RCKu4D37x09vg4h8irDIhF/%EB%94%94%ED%94%84%EB%A7%8C-1%ED%8C%80-%EC%9E%90%EB%A6%B0%EA%B3%A0%EB%B9%84-%EB%94%94%EC%9E%90%EC%9D%B8?type=design&node-id=809-8286&t=sTfu0zxLXjqKY1ZS-0)

### 특이사항

className이 string literal로 되어 있습니다. 창완님 쪽에서 tailwind-merge를 사용해주셨는데, 후에 창완님 브랜치가 머지되면 적용해놓도록 하겠습니다.

## Demo

### 작은 사이즈 - 30px

https://github.com/depromeet/jaringobi/assets/40374023/703e7e99-deac-42fd-91fd-eaadaf754fc4

### 큰 사이즈 - 48px

https://github.com/depromeet/jaringobi/assets/40374023/7a84e9a6-3d65-4091-8d65-6218e099be15

# 특징

- 토글버튼 컴포넌트의 전체적인 사이즈가 width에 따라 자동으로 비율이 정해지도록 했습니다.
  왔다갔다 하는 하얀 버튼 토글이 absolute이기 때문에 비율이 일정하기 때문에, 유지할 필요가 있었습니다.
  **훗날 custom이 필요하면 width만 조정해주시면 됩니다!**

