### PR TITLE
Fix/bottom nav

### DIFF
--- a/src/pages/my-poor-room/index.tsx
+++ b/src/pages/my-poor-room/index.tsx
@@ -15,7 +15,7 @@ export default function MyPoorRoom() {
   const isMyRoom = !challengeId;
 
   return (
-    <div className="h-full bg-gray-10">
+    <div className="bg-gray-10">
       <Spacing height={86} />
       <div className="fixed top-0 z-10 w-full bg-white">
         <ChallengeCategories />

--- a/src/shared/components/layout/BottomNavLayout.tsx
+++ b/src/shared/components/layout/BottomNavLayout.tsx
@@ -9,16 +9,7 @@ type BottomNavLayoutProps = {
 export default function BottomNavLayout({ children }: BottomNavLayoutProps) {
   return (
     <div className="flex h-screen flex-col">
-      {/* 
-        TODO: 창완님 overflow-auto의 경우 각 페이지 내부에서 하는게 맞는 것 같은데 어떻게 생각하세요 ? 
-        창완님께서 작성해주신 거지방 탐색의 경우에도 list만 scroll 되는게 맞는 것 같아서요 ! 
-
-        추가적으로 제가 기존에 짰던 코드가 페이지 내부에서 overflow를 사용하고 있어서 현재 사이드 이펙트가 발생하고 있어요.
-
-        BottomNavLayout과 같이 공통으로 사용되는 컴포넌트의 경우 사이드 이펙트가 발생할 여지가 크니까, 사용하는 모든 곳에서 
-        사이드 이펙트가 발생하지 않는지 확인해주시고 고쳐주세요 ㅠ
-      */}
-      <div className="flex-1 overflow-auto">{children}</div>
+      <div className="flex-1 pb-bottom-nav">{children}</div>
       <BottomNavigation />
     </div>
   );

--- a/src/shared/components/layout/GlobalLayout.tsx
+++ b/src/shared/components/layout/GlobalLayout.tsx
@@ -9,9 +9,7 @@ type GlobalLayoutProps = {
 export default function GlobalLayout({ children }: GlobalLayoutProps) {
   return (
     <ApplyingFont>
-      <div className="mx-auto my-0 h-screen w-full max-w-[600px]">
-        {children}
-      </div>
+      <div className="mx-auto my-0 w-full max-w-[600px]">{children}</div>
     </ApplyingFont>
   );
 }

--- a/src/shared/components/navigation/BottomNavigation.tsx
+++ b/src/shared/components/navigation/BottomNavigation.tsx
@@ -33,7 +33,7 @@ export default function BottomNavigation() {
   };
 
   return (
-    <div className="flex h-[60px] w-screen flex-[0_0_60px] items-center justify-around bg-white">
+    <div className="fixed bottom-0 flex h-bottom-nav w-screen items-center justify-around bg-white">
       <button type="button">
         <Link className="flex flex-col items-center" href="/search">
           <IconSearch

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,9 @@ module.exports = {
   content: ['./public/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      spacing: {
+        'bottom-nav': '60px',
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':


### PR DESCRIPTION
## window.scrollTo 가 안되는 현상을 수정했습니다

css가 간단하면서도 복잡하네요 🥲
원인은 다음으로 추측되네요

scrollTo는 body를 context를 가지고 있는데, 중간에 overflow-auto를 지정할 시 body는 화면의 높이 (650px)가 고정되어서 이런 scrollTo가 작동하지 않는 현상이 발생한 것 같습니다. 
사실, overflow-y-auto 로 지정한 <div> element 상위 요소에 height가 지정되지 않았다면 body도 자식의 높이만큼 가지게 되어 이런 문제가 발생하지 않지만, 저희는 모바일 뷰를 지원해야하기 때문에 h-screen을 사용해어야 해서 overflow-auto를 삭제해서 해결했습니다

```jsx
  <div className="flex h-screen flex-col">
      <div className="flex-1 overflow-y-auto">{children}</div>
      <BottomNavigation />
    </div>
```
관련 링크:
https://stackoverflow.com/questions/1174863/javascript-scrollto-method-does-nothing